### PR TITLE
Fix warning from accessing React.PropTypes instead of prop-types package

### DIFF
--- a/dist/react-keybinding-component.js
+++ b/dist/react-keybinding-component.js
@@ -1,18 +1,22 @@
 'use strict';
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var _propTypes = require('prop-types');
 
-function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj; }
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -20,13 +24,13 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var KeybindingComponent = (function (_Component) {
+var KeybindingComponent = function (_Component) {
     _inherits(KeybindingComponent, _Component);
 
     function KeybindingComponent(props) {
         _classCallCheck(this, KeybindingComponent);
 
-        var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(KeybindingComponent).call(this, props));
+        var _this = _possibleConstructorReturn(this, (KeybindingComponent.__proto__ || Object.getPrototypeOf(KeybindingComponent)).call(this, props));
 
         _this.state = {};
         _this.onKey = _this.onKey.bind(_this);
@@ -59,7 +63,7 @@ var KeybindingComponent = (function (_Component) {
     }]);
 
     return KeybindingComponent;
-})(_react.Component);
+}(_react.Component);
 
 KeybindingComponent.defaultProps = {
     onKey: function onKey() {},
@@ -71,12 +75,12 @@ KeybindingComponent.defaultProps = {
 };
 
 KeybindingComponent.propTypes = {
-    onKey: _react2.default.PropTypes.func,
-    type: _react2.default.PropTypes.string,
-    target: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.object]),
-    preventInputConflict: _react2.default.PropTypes.bool,
-    preventDefault: _react2.default.PropTypes.bool,
-    stopPropagation: _react2.default.PropTypes.bool
+    onKey: _propTypes2.default.func,
+    type: _propTypes2.default.string,
+    target: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
+    preventInputConflict: _propTypes2.default.bool,
+    preventDefault: _propTypes2.default.bool,
+    stopPropagation: _propTypes2.default.bool
 };
 
 exports.default = KeybindingComponent;

--- a/js/react-keybinding-component.jsx
+++ b/js/react-keybinding-component.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 
 class KeybindingComponent extends Component {
 
@@ -44,7 +44,7 @@ KeybindingComponent.defaultProps = {
 KeybindingComponent.propTypes = {
     onKey                : PropTypes.func,
     type                 : PropTypes.string,
-    target               : PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object ]),
+    target               : PropTypes.oneOfType([PropTypes.string, PropTypes.object ]),
     preventInputConflict : PropTypes.bool,
     preventDefault       : PropTypes.bool,
     stopPropagation      : PropTypes.bool

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-keybinding-component",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A React keybinding component, usable with es6, no mixin",
   "main": "dist/react-keybinding-component.js",
   "scripts": {


### PR DESCRIPTION
Hi there -- thanks for making such a helpful package. I saw you released 0.5.0 a few weeks ago to fix warnings from directly accessing `React.PropTypes` but it looks like a few things were missed as I'm still seeing prop types warnings. This PR should eliminate them. Thanks!

* Fix import from prop-types (no braces required)
* Fix a couple prop types that were still using React.PropTypes
* Run gulp task to update `dist` output (it didn't seem to be updated, even in 0.5.0 the dist build was still using `React.PropTypes`
* Bump package version to 0.5.1